### PR TITLE
Allow local contact import to work on Cyanogen.

### DIFF
--- a/flock/src/main/java/org/anhonesteffort/flock/ImportContactsFragment.java
+++ b/flock/src/main/java/org/anhonesteffort/flock/ImportContactsFragment.java
@@ -232,7 +232,7 @@ public class ImportContactsFragment extends AccountAndKeyRequiredFragment
 
         else {
           rawContactsUri               = ContactsContract.RawContacts.CONTENT_URI;
-          cursor                       = client.query(rawContactsUri, null, ContactsContract.RawContacts.ACCOUNT_TYPE + " IS NULL", null, null);
+          cursor                       = client.query(rawContactsUri, null, ContactsContract.RawContacts.ACCOUNT_TYPE + " IN (NULL, 'com.android.localphone')", null, null);
           accountDetails.contact_count = cursor.getCount();
           Log.d(TAG, "local storage has " +  accountDetails.contact_count + " contacts");
         }


### PR DESCRIPTION
Fixes #85

AOSP uses a null ACCOUNT_TYPE for local contacts, whereas it seems CM
uses `com.android.localphone`.

I don't have an android dev environment set up on my current workstation, so this is untested :(
