### PR TITLE
Add flag to skip nonplay build for non-OWS developers.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -24,7 +24,7 @@ The following steps should help you (re)build flock from the command line.
 
 5. Execute Gradle:
 
-        ./gradlew build
+        ./gradlew build -Pskip-nonplay
 
 Setting up a development environment
 ------------------------------------

--- a/flock/build.gradle
+++ b/flock/build.gradle
@@ -19,6 +19,16 @@ android {
         nonplay { }
     }
 
+    variantFilter { variant ->
+        // If `-Pskip-nonplay` arg is provided, skip build flavor
+        // since libsupplychain library isn't yet public.
+        if (project.hasProperty('skip-nonplay')) {
+            if (variant.getFlavors().get(0).name.equals('nonplay')) {
+                variant.setIgnore(true);
+            }
+        }
+    }
+
     packagingOptions {
         exclude 'META-INF/NOTICE'
         exclude 'META-INF/LICENSE'


### PR DESCRIPTION
Resolves #94.

I choose to leave the vanilla build command as-is, so that this won't break scripts you guys have internally :)
